### PR TITLE
Fix YouTube download compatibility for 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The menu also offers yt-dlp updates (option 2) and optional GPU support (option 
   - Note: Scene detection and deblock filter work without FFmpeg
 - PyCUDA (optional) - for NVIDIA GPU acceleration
 
-**Important:** Keep yt-dlp updated regularly. Use startup script option 2, or run: `pip install --upgrade yt-dlp`
+**Important:** Keep yt-dlp updated regularly — YouTube compatibility breaks frequently. Use startup script option 2, or run: `pip install --upgrade "yt-dlp[default]"`
 
 ## Manual Installation
 
@@ -66,6 +66,9 @@ cd youtube-screenshot-extractor
 python -m venv venv
 venv\Scripts\activate
 pip install -r requirements.txt
+
+# Keep yt-dlp current (run periodically for YouTube compatibility)
+pip install --upgrade "yt-dlp[default]"
 
 # Install Deno (required for YouTube)
 winget install DenoLand.Deno
@@ -81,6 +84,9 @@ cd youtube-screenshot-extractor
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+
+# Keep yt-dlp current (run periodically for YouTube compatibility)
+pip install --upgrade "yt-dlp[default]"
 
 # Install Deno (required for YouTube)
 # macOS:
@@ -162,8 +168,8 @@ Frames are saved as: `frame_NNNNNN_qXX_bYY[_watermarked].(jpg|png)`
 
 | Problem | Solution |
 |---------|----------|
-| YouTube download fails | Install Deno (required since Nov 2025):<br>Windows: `winget install DenoLand.Deno`<br>macOS: `brew install deno`<br>Linux: `curl -fsSL https://deno.land/install.sh \| sh` |
-| Authentication/download errors | Update yt-dlp: `pip install --upgrade yt-dlp` |
+| YouTube download fails | 1. Update yt-dlp: `pip install --upgrade "yt-dlp[default]"`<br>2. Install/update Deno (required):<br>Windows: `winget install DenoLand.Deno`<br>macOS: `brew install deno`<br>Linux: `curl -fsSL https://deno.land/install.sh \| sh` |
+| Authentication/download errors | Update yt-dlp: `pip install --upgrade "yt-dlp[default]"` |
 | "Format not available" error | Remove resolution limit or try a different source - some sites have limited formats |
 | No frames extracted | Lower thresholds: `--quality 20 --blur 30` |
 | Keyframe extraction fails | Ensure FFmpeg is installed and in PATH |

--- a/START.bat
+++ b/START.bat
@@ -150,7 +150,7 @@ if not exist "venv" (
 call venv\Scripts\activate.bat
 echo  Checking for yt-dlp updates...
 echo.
-uv pip install --upgrade yt-dlp 2>nul || pip install --upgrade yt-dlp
+uv pip install --upgrade "yt-dlp[default]" 2>nul || pip install --upgrade "yt-dlp[default]"
 echo.
 echo  yt-dlp has been updated to the latest version.
 echo.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-yt-dlp>=2025.12.8
+yt-dlp[default]>=2026.3.17
 opencv-python>=4.10.0
 numpy>=2.0.0
 Pillow>=11.0.0

--- a/start.sh
+++ b/start.sh
@@ -196,9 +196,9 @@ update_ytdlp() {
     echo ""
 
     if command -v uv &> /dev/null; then
-        uv pip install --upgrade yt-dlp
+        uv pip install --upgrade "yt-dlp[default]"
     else
-        pip install --upgrade yt-dlp
+        pip install --upgrade "yt-dlp[default]"
     fi
 
     echo ""

--- a/youtube-screenshot-script.py
+++ b/youtube-screenshot-script.py
@@ -158,6 +158,14 @@ def download_video(url, output_path, max_resolution=None, verbose=False):
             elif 'Private video' in error_msg or 'Sign in' in error_msg:
                 safe_print("Error: This video is private or requires authentication.")
                 raise
+            elif any(k in error_msg for k in ('jsinterp', 'JavaScript', 'js interpreter', 'Deno', 'deno', 'external player')):
+                safe_print("Error: A JavaScript runtime is required for YouTube downloads.")
+                safe_print("Install Deno and ensure it is in your PATH:")
+                safe_print("  Windows: winget install DenoLand.Deno  (or use START.bat option 3)")
+                safe_print("  macOS:   brew install deno             (or use start.sh option 3)")
+                safe_print("  Linux:   curl -fsSL https://deno.land/install.sh | sh")
+                safe_print("Also ensure yt-dlp is up to date: pip install --upgrade \"yt-dlp[default]\"")
+                raise
             else:
                 if attempt < max_retries - 1:
                     safe_print(f"Download attempt {attempt + 1} failed. Retrying...")


### PR DESCRIPTION
yt-dlp has required the [default] extras (which bundles yt-dlp-ejs, the
embedded JS framework) since early 2026 for full YouTube support. The plain
yt-dlp package no longer works reliably with YouTube as of ~Jan-Feb 2026.

- requirements.txt: bump yt-dlp to yt-dlp[default]>=2026.3.17
- START.bat / start.sh: update the "Update yt-dlp" menu option to install
  yt-dlp[default] so users who run option 2 get the required extras
- youtube-screenshot-script.py: add specific error handling for missing
  JS runtime errors with clear install instructions
- README.md: update all update commands to use yt-dlp[default], add step
  to manual install sections, reorder troubleshooting to lead with update

https://claude.ai/code/session_01VWRuH8JN8CtddfRYF5u2dz